### PR TITLE
Add webhook for track items

### DIFF
--- a/electron/src/utils/__mocks__/log-manager.ts
+++ b/electron/src/utils/__mocks__/log-manager.ts
@@ -5,5 +5,6 @@ export const logManager = {
         debug: vi.fn(),
         error: vi.fn(),
         info: vi.fn(),
+        warn: vi.fn(),
     }),
 };


### PR DESCRIPTION
## Summary
- send a POST request with track item data whenever a new item is saved
- fix logger mock to include a `warn` stub

## Testing
- `npm test --silent` in `electron`
- `npm test --silent` in `client`
